### PR TITLE
Add comprehensive documentation for STOP implementation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# STOP Implementation Documentation
+
+This directory contains detailed documentation for the STOP model implementation. Each file in the repository is described with its purpose, key functions or classes, and its role in the overall system. Use the links below to navigate to documentation for specific components.
+
+## Contents
+
+- [Main Application](main.md)
+- [Hyperparameters](params.md)
+- [Data Loaders](dataloaders.md)
+- [Model Modules](modules/README.md)
+- [Preprocessing Utilities](preprocess.md)
+- [Utility Helpers](utils.md)
+- [Scripts and Execution](scripts.md)
+- [Dataset Annotations](dataset.md)
+- [Miscellaneous Files](misc.md)

--- a/docs/dataloaders.md
+++ b/docs/dataloaders.md
@@ -1,0 +1,16 @@
+# Data Loaders
+
+This directory provides dataset interfaces and video decoding utilities.
+
+## Retrieval Datasets
+- **`data_dataloaders.py`**: registry mapping dataset names to loader constructors. Exposes `dataloader_msrvtt_train` and `dataloader_msrvtt_test` used by `main.py`.
+- **`dataloader_msrvtt_retrieval.py`**: training and evaluation loaders for the MSRVTT captioning dataset. Includes `MSRVTT_DataLoader` and `MSRVTT_TrainDataLoader` classes handling tokenisation, frame sampling and video decoding.
+- **`dataloader_activitynet_retrieval.py`**: loader for ActivityNet text-video retrieval. Builds caption dictionaries and sampling of temporal segments.
+- **`dataloader_didemo_retrieval.py`**: dataset wrapper for the DiDeMo benchmark with support for multiple captions per video clip.
+- **`dataloader_vatex_retrieval.py`**: implements VATEX training and validation loaders.
+
+## Video Decoding and Augmentation
+- **`decode.py`**: `RawVideoExtractorpyAV` uses PyAV to sample and transform frames with optional LMDB-backed storage.
+- **`rawvideo_util.py`**: alternative frame extraction using OpenCV; exposes `RawVideoExtractorCV2` and helper functions for frame ordering.
+- **`sampling.py`**: uniform and multi-segment temporal sampling strategies.
+- **`transforms.py`**: tensor-based normalisation, cropping and conversion utilities used during decoding.

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -1,0 +1,17 @@
+# Dataset Annotations
+
+Sample annotation files used for experimentation and unit tests. These files provide minimal subsets of larger benchmarks.
+
+## ActivityNet
+- `train.json`, `val_1.json`: caption annotations for training and validation.
+- `train_ids.json`, `val_ids.json`: lists of video identifiers.
+- `video_path.json`: mapping from video identifiers to file system paths.
+- `train_list.txt`, `val_1_list.txt`: text lists of video files for preprocessing.
+
+## LSMDC
+- `LSMDC16_challenge_1000_publictect.csv`: evaluation CSV from the LSMDC challenge.
+
+## MSVD
+- `train_list.txt`, `val_list.txt`, `test_list.txt`: video identifier splits for the MSVD dataset.
+
+These annotations are consumed by the loaders in `dataloaders/` and by preprocessing scripts to locate and parse video-caption pairs.

--- a/docs/main.md
+++ b/docs/main.md
@@ -1,0 +1,21 @@
+# Main Application
+
+## `main.py`
+Implements the full training and evaluation loop for STOP. Major responsibilities include:
+
+- Parsing configuration through `params.get_args`.
+- Initialising distributed training and logging utilities.
+- Constructing the `CLIP4Clip` model with optional frozen backbone and temporal prompting modules.
+- Building dataset loaders via `dataloaders.data_dataloaders.DATALOADER_DICT`.
+- Running training epochs with `train_epoch` and evaluation with `eval_epoch`.
+- Saving checkpoints using `utils.misc.save_checkpoint` and reporting retrieval metrics from `utils.metrics`.
+
+Key entry points:
+
+- `main(args)`: orchestrates setup and spawns worker processes for distributed execution.
+- `main_worker(gpu, ngpus_per_node, log_queue, args)`: configures the model, optimisers, and dataloaders.
+- `train_epoch(...)`: performs one optimisation epoch with optional mixed precision.
+- `eval_epoch(...)`: caches text and video features then computes similarity scores.
+- `_run_on_single_gpu(...)`: helper for similarity computation between cached text and video representations.
+
+The script interacts extensively with modules under `modules/`, dataset loaders under `dataloaders/`, and utilities from `utils/` for logging, optimisation, and distributed training.

--- a/docs/misc.md
+++ b/docs/misc.md
@@ -1,0 +1,11 @@
+# Miscellaneous Files
+
+Supporting assets and configuration.
+
+- **`environment.yaml`**: Conda environment specification listing required packages and versions.
+- **`LICENSE`**: project license (Apache-2.0).
+- **`readme.md`**: high-level overview and quick-start instructions.
+- **`qb_norm_sim_matrix/`**: precomputed similarity matrices (`*.npy`) used by `search_for_best_r1_with_qb_norm.py` for normalisation experiments.
+- **`figs/Framework.png`, `figs/Result_1.png`**: figures reproduced from the paper.
+
+These files do not contain executable code but provide context, configuration, and resources for running the project.

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -1,0 +1,15 @@
+# Model Modules
+
+Detailed documentation for the core modules that implement the STOP model. The files below correspond to code in the `modules/` directory and describe their purpose, key classes or functions, inputs and outputs, and how they interact with the rest of the system.
+
+- [`__init__.py`](init.md) – exposes the primary public interfaces such as `CLIP4Clip`, `SimpleTokenizer`, and `convert_weights`.
+- [`base.py`](base.md) – configuration management and `PreTrainedModel` utilities for weight loading and initialisation.
+- [`clip.py`](clip.md) – adapts OpenAI CLIP with temporal prompting hooks for video encoding.
+- [`clip4clip.py`](clip4clip.md) – main STOP retrieval model combining CLIP encoders with cross-modal interaction and temporal modelling.
+- [`module_cross.py`](module_cross.md) – cross-modal Transformer that fuses video and text representations.
+- [`losses.py`](losses.md) – training objectives including cross-entropy and ranking losses.
+- [`file.py`](file.md) – cache-aware resource loader for HTTP and S3 sources.
+- [`simple_tokenizer.py`](simple_tokenizer.md) – byte-pair encoding tokenizer used by the text encoder.
+- [`temporal_prompting.py`](temporal_prompting.md) – constructs temporal prompts that modulate frame features.
+- [`utils.py`](utils.md) – distributed training helpers and attribute utilities.
+- [`cross-base/cross_config.json`](cross_config.md) – default hyperparameters for the cross-modal Transformer.

--- a/docs/modules/base.md
+++ b/docs/modules/base.md
@@ -1,0 +1,23 @@
+# `base.py`
+
+Infrastructure for configuration management and a base class for pretrained models.
+
+## Key Classes
+
+- **`PretrainedConfig`**
+  - Loads configuration and associated weights from local files or URLs via `get_config`.
+  - Serialises and deserialises settings through `from_json_file`, `from_dict`, `to_dict`, and `to_json_string`.
+  - Tracks archive map names (`config_name`, `weights_name`) used by `CrossModel`.
+
+- **`PreTrainedModel`**
+  - Parent for all learnable modules requiring pretrained weights.
+  - Handles parameter initialisation (`init_weights`) and weight loading (`init_preweight`).
+  - Exposes abstract `resize_token_embeddings` for token embedding adjustment.
+
+## Activation Helpers
+
+Defines common activation functions `gelu`, `swish`, and a lookup table `ACT2FN` so modules can reference them consistently.
+
+## Interaction Within STOP
+
+`CLIP4Clip`, `CrossModel`, and other models inherit from `PreTrainedModel` to share loading utilities and weight initialisation. Configuration objects derived from `PretrainedConfig` drive the construction of these models.

--- a/docs/modules/clip.md
+++ b/docs/modules/clip.md
@@ -1,0 +1,28 @@
+# `clip.py`
+
+Port of OpenAI's CLIP model with additional hooks for temporal prompting.
+
+## Components
+
+- **Vision Backbone**
+  - `Bottleneck`, `ModifiedResNet` and `AttentionPool2d` implement ResNet-based encoders.
+  - `VisualTransformer` provides a Vision Transformer alternative.
+
+- **Text Encoder**
+  - `Transformer` composed of `ResidualAttentionBlock` layers with `LayerNorm` and `QuickGELU` activations.
+
+- **Prompt-enabled Blocks**
+  - `PromptResidualAttentionBlock` and `PromptTransformer` allow injecting temporal prompts into the Transformer stack.
+
+- **`CLIP` Class**
+  - Wraps visual and text encoders, exposing `encode_image`, `encode_text` and `forward` for joint embeddings.
+  - Maintains a learnable `logit_scale` to balance similarity scores.
+
+- **Utility Functions**
+  - `convert_weights` casts model parameters to `fp16` for efficient inference.
+  - `build_clip_model` constructs a CLIP model from a state dictionary.
+  - `load_clip_state_dict`, `_download`, and `available_models` manage retrieval of pretrained weights from the internet or cache.
+
+## Role in STOP
+
+`CLIP` serves as the backbone for both modalities in `CLIP4Clip`. Temporal prompting classes interact with `temporal_prompting.py` to integrate frame-wise prompts during video encoding.

--- a/docs/modules/clip4clip.md
+++ b/docs/modules/clip4clip.md
@@ -1,0 +1,27 @@
+# `clip4clip.py`
+
+Implements the STOP video–text retrieval model by extending CLIP to handle temporal sequences and cross-modal reasoning.
+
+## Key Classes
+
+- **`CLIP4ClipPreTrainedModel`**
+  - Inherits from `PreTrainedModel` and encapsulates both CLIP and cross-modal components.
+  - The `from_pretrained` class method loads a pretrained CLIP backbone, initialises cross-modal parameters and applies optional temperature scaling.
+
+- **`TemporalModelling`**
+  - Stack of `ResidualAttentionBlock` layers that aggregates per-frame features.
+  - Configurable via width, number of layers and attention heads.
+
+- **`CLIP4Clip`**
+  - Combines CLIP image/text encoders with a `CrossModel` from [`module_cross.py`](module_cross.md).
+  - Supports multiple similarity headers (e.g., `meanP`, `seqLSTM`, `tightTransf`) and temporal prompt injection through `get_TemporalPrompt`.
+  - Computes video–text similarities and applies the `CrossEn` loss during training.
+  - Utilises distributed helpers `all_gather`, `log_info` and `update_attr` from [`utils.py`](utils.md).
+
+## Supporting Layers
+
+Auxiliary definitions such as `QuickGELU`, `LayerNorm`, and `ResidualAttentionBlock` enable efficient Transformer-style computations.
+
+## Interaction
+
+`CLIP4Clip` is the primary model trained and evaluated in STOP. It orchestrates frame encoding, temporal modelling, cross-modal fusion and loss computation to produce retrieval logits.

--- a/docs/modules/cross_config.md
+++ b/docs/modules/cross_config.md
@@ -1,0 +1,18 @@
+# `cross-base/cross_config.json`
+
+Default configuration file for the cross-modal Transformer.
+
+| Field | Description |
+|-------|-------------|
+| `hidden_size` | Dimensionality of token embeddings (512). |
+| `num_hidden_layers` | Number of Transformer layers (4). |
+| `num_attention_heads` | Multi-head attention heads (8). |
+| `intermediate_size` | Feed-forward layer size (2048). |
+| `hidden_act` | Activation function (`gelu`). |
+| `hidden_dropout_prob` | Dropout applied to fully connected layers (0.1). |
+| `attention_probs_dropout_prob` | Dropout on attention weights (0.1). |
+| `max_position_embeddings` | Maximum sequence length (77). |
+| `vocab_size` | Token vocabulary size for joint inputs (512). |
+| `initializer_range` | Standard deviation for parameter initialisation (0.02). |
+
+`CrossConfig` in [`module_cross.py`](module_cross.md) loads these parameters when constructing the `CrossModel`.

--- a/docs/modules/file.md
+++ b/docs/modules/file.md
@@ -1,0 +1,15 @@
+# `file.py`
+
+Utility functions for locating, downloading and caching external resources such as pretrained weights.
+
+## Highlights
+
+- **Caching Helpers**
+  - `url_to_filename` and `filename_to_url` map URLs to deterministic cache filenames.
+  - `cached_path` resolves a local path or downloads a remote file (HTTP/S3), storing metadata for future reuse.
+
+- **S3/HTTP Interfaces**
+  - `split_s3_path`, `s3_etag`, `s3_get` and `http_get` handle platform-specific downloads.
+  - `get_from_cache` orchestrates retrieval using ETag-based caching and progress bars via `tqdm`.
+
+These utilities are leveraged by configuration loaders in [`base.py`](base.md) and model builders like [`clip.py`](clip.md) to transparently fetch pretrained checkpoints.

--- a/docs/modules/init.md
+++ b/docs/modules/init.md
@@ -1,0 +1,9 @@
+# `__init__.py`
+
+Provides convenient, package-level imports for frequently used components. Importing `modules` exposes:
+
+- **`CLIP4Clip`** – main video–text retrieval model defined in [`clip4clip.py`](clip4clip.md).
+- **`SimpleTokenizer`** – byte‑pair encoding tokenizer from [`simple_tokenizer.py`](simple_tokenizer.md).
+- **`convert_weights`** – utility function from [`clip.py`](clip.md) that converts model parameters to half precision.
+
+These symbols allow users to construct models and tokenizers without referencing deep module paths.

--- a/docs/modules/losses.md
+++ b/docs/modules/losses.md
@@ -1,0 +1,20 @@
+# `losses.py`
+
+Collection of training objectives used for contrastive video–text retrieval.
+
+## Loss Functions
+
+- **`CrossEn`**
+  - Computes cross-entropy over similarity matrices by applying `log_softmax` along the text dimension and averaging the negative log-diagonal.
+
+- **`MILNCELoss`**
+  - Implements the Multiple Instance Learning variant of InfoNCE.
+  - Uses a block mask to handle multiple positive pairs per sample and aggregates negatives from both modalities.
+
+- **`MaxMarginRankingLoss`**
+  - Margin-based ranking objective with optional negative weighting.
+  - Supports hard/easy negative sampling via `hard_negative_rate` and scales losses when multiple pairs are present.
+
+## Role in STOP
+
+`CLIP4Clip` primarily employs `CrossEn` but alternative losses can be used for experimentation with different retrieval criteria.

--- a/docs/modules/module_cross.md
+++ b/docs/modules/module_cross.md
@@ -1,0 +1,18 @@
+# `module_cross.py`
+
+Defines the cross-modal Transformer used to fuse visual and textual embeddings.
+
+## Configuration
+
+- **`CrossConfig`** extends `PretrainedConfig` and stores hyperparameters such as hidden size, number of layers, attention heads and dropout rates. Configurations are typically loaded from [`cross_config.json`](cross_config.md).
+
+## Model Architecture
+
+- **`CrossEmbeddings`** adds positional encodings to concatenated video and text features.
+- **`ResidualAttentionBlock`** and **`Transformer`** implement multi-head self-attention over the joint sequence.
+- **`CrossPooler`** normalises and projects the `[CLS]` token representation.
+- **`CrossModel`** wraps embeddings, transformer and pooler, and exposes a forward pass that returns pooled video–text features.
+
+## Usage in STOP
+
+`CLIP4Clip` instantiates `CrossModel` to compute interaction-aware representations before similarity scoring. The configuration and parameter initialisation leverage `PreTrainedModel` utilities from [`base.py`](base.md).

--- a/docs/modules/simple_tokenizer.md
+++ b/docs/modules/simple_tokenizer.md
@@ -1,0 +1,14 @@
+# `simple_tokenizer.py`
+
+Lightweight byte‑pair encoding (BPE) tokenizer compatible with CLIP.
+
+## Features
+
+- Loads merges from `bpe_simple_vocab_16e6.txt` (included in the repository) using cached helpers.
+- Implements text normalisation via `basic_clean` and `whitespace_clean`.
+- Provides `encode`, `decode`, `tokenize`, and `convert_tokens_to_ids` methods for preprocessing captions.
+- Uses `bytes_to_unicode` mappings to ensure reversible encoding.
+
+## Usage
+
+The tokenizer is constructed implicitly when `SimpleTokenizer` is imported through [`__init__.py`](init.md). It converts raw strings into integer token IDs consumed by the CLIP text encoder.

--- a/docs/modules/temporal_prompting.md
+++ b/docs/modules/temporal_prompting.md
@@ -1,0 +1,15 @@
+# `temporal_prompting.py`
+
+Generates learnable prompts that modulate frame features before encoding.
+
+## API
+
+- **`get_TemporalPrompt(args)`** – factory function returning a prompt module based on `args.temporal_prompt`.
+- **`TemporalPrompt_3`**
+  - Applies a series of 3D convolutions followed by an MLP to produce per-frame prompt tokens.
+  - `get_mask` computes saliency masks via a dedicated convolutional network.
+  - `init_InterFramePrompt` and `get_inter_frame_prompt` introduce inter-frame attention for enhanced temporal context.
+
+## Interaction
+
+`clip4clip.py` calls `get_TemporalPrompt` to attach prompt generators that inject additional tokens or masks into the CLIP visual encoder, enabling temporal adaptation.

--- a/docs/modules/utils.md
+++ b/docs/modules/utils.md
@@ -1,0 +1,15 @@
+# `utils.py`
+
+Miscellaneous helper functions used across the STOP codebase.
+
+## Logging and Configuration
+
+- **`log_info`** – rank-aware logger that prints messages only from the main distributed process.
+- **`update_attr`** – copies attributes from one configuration object to another, respecting default values.
+
+## Distributed Utilities
+
+- **`AllGather` autograd function** – gathers tensors from all workers while retaining gradients for backpropagation.
+- **`all_gather`** – convenience wrapper that returns the concatenated tensor across distributed processes.
+
+These functions support multi-GPU training and are used extensively in [`clip4clip.py`](clip4clip.md) for contrastive learning with large negative pools.

--- a/docs/params.md
+++ b/docs/params.md
@@ -1,0 +1,10 @@
+# Hyperparameters
+
+## `params.py`
+Centralised configuration for experiments.
+
+- `get_default_params(model_name)`: returns recommended optimiser defaults for a given CLIP backbone.
+- `get_args(description)`: defines the full command line interface for training and evaluation. Parameters cover dataset paths, optimisation settings, distributed training, prompt design, and precision options. Returns a populated `argparse.Namespace` and ensures output directories exist.
+- `save_hp_to_json(directory, args)`: helper to persist hyperparameters to `hparams_train.json` for reproducibility.
+
+The module is consumed by `main.py` to configure runs and by preprocessing scripts that require consistent hyperparameters.

--- a/docs/preprocess.md
+++ b/docs/preprocess.md
@@ -1,0 +1,12 @@
+# Preprocessing Utilities
+
+Scripts for preparing raw video data and annotations prior to training.
+
+- **`check_video.py`**: verifies video integrity and logs problematic files.
+- **`compress_video.py`**: rescales and compresses videos to the target resolution and bitrate.
+- **`folder2lmdb.py`**: converts a directory of video files into an LMDB database for efficient random access.
+- **`generate_video_path.py`**: builds `video_path.json` mappings from video identifiers to file locations.
+- **`patch_video.py`**: applies spatial patches or crops to video frames for data augmentation.
+- **`visualize_video.py`**: utility for rendering sampled frames to check preprocessing results.
+
+These tools operate independently of the training code but ensure data conforms to the expected format consumed by loaders in `dataloaders/`.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,0 +1,11 @@
+# Scripts and Execution
+
+Shell scripts and utilities to reproduce experiments.
+
+- **`scripts/msrvtt.sh`**: example command line for training on the MSRVTT dataset.
+- **`scripts/activitynet.sh`**: training script for ActivityNet retrieval.
+- **`scripts/vatex.sh`**: training configuration for VATEX.
+- **`kill.sh`**: helper to terminate residual training processes.
+- **`search_for_best_r1_with_qb_norm.py`**: evaluates different QB normalization strategies to maximise R@1.
+
+These scripts rely on `main.py` and `params.py` and provide ready-to-use experiment setups.

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -1,0 +1,10 @@
+# Utility Helpers
+
+Supporting modules used across training and evaluation.
+
+- **`dist_utils.py`**: wrappers for PyTorch distributed utilities (`init_distributed_mode`, `get_rank`, `is_master`).
+- **`log.py`**: logging configuration with queue-based handlers for multi-process setups.
+- **`lr_scheduler.py`**: cosine learning-rate scheduler with warmup (`lr_scheduler` function).
+- **`metrics.py`**: retrieval metric computation including recall at K and mean rank.
+- **`misc.py`**: miscellaneous helpers such as random seed setting, model checkpoint saving, and float precision conversions.
+- **`optimization.py`**: optimiser utilities, notably `BertAdam` and helper `prep_optim_params_groups` for parameter-specific learning rates.


### PR DESCRIPTION
## Summary
- Create `docs/modules/` with dedicated guides for each file in the `modules/` package
- Link new module documentation from the main docs index
- Remove outdated `docs/modules.md` in favor of per-file references

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b03a72c2448327bbf1756687f93a4e